### PR TITLE
fix: Update profile update for security

### DIFF
--- a/src/main/java/org/sitmun/verification/controller/VerificationController.java
+++ b/src/main/java/org/sitmun/verification/controller/VerificationController.java
@@ -14,6 +14,7 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -41,9 +42,14 @@ public class VerificationController {
       @Valid @RequestBody UserPasswordAuthenticationRequest body) {
     ResponseEntity<Boolean> response;
     try {
+      // Get current username from authentication
+      Authentication currentAuth = SecurityContextHolder.getContext().getAuthentication();
+      String currentUsername = currentAuth.getName();
+
+      // Check if the password is correct
       Authentication authentication =
-          authenticationManager.authenticate(
-              new UsernamePasswordAuthenticationToken(body.getUsername(), body.getPassword()));
+        this.authenticationManager.authenticate(
+          new UsernamePasswordAuthenticationToken(currentUsername, body.getPassword()));
       response = new ResponseEntity<>(authentication.isAuthenticated(), HttpStatus.OK);
     } catch (BadCredentialsException e) {
       log.warn("Invalid credentials for user {}: {}", body.getUsername(), e.getMessage());


### PR DESCRIPTION
The username is taken from the credentials to ensure that nobody can change the username from the received request body.