### PR TITLE
Parametrized services with system variables

### DIFF
--- a/src/main/java/org/sitmun/authorization/proxy/service/ProxyConfigurationService.java
+++ b/src/main/java/org/sitmun/authorization/proxy/service/ProxyConfigurationService.java
@@ -19,6 +19,7 @@ import org.sitmun.authorization.proxy.protocols.jdbc.JdbcPayloadDto;
 import org.sitmun.authorization.proxy.protocols.wms.WmsPayloadDto;
 import org.sitmun.authorization.proxy.validator.ResourceAccessValidator;
 import org.sitmun.domain.DomainConstants;
+import org.sitmun.domain.application.Application;
 import org.sitmun.domain.application.ApplicationRepository;
 import org.sitmun.domain.database.DatabaseConnection;
 import org.sitmun.domain.service.Service;
@@ -28,6 +29,7 @@ import org.sitmun.domain.task.Task;
 import org.sitmun.domain.task.TaskRepository;
 import org.sitmun.domain.territory.Territory;
 import org.sitmun.domain.territory.TerritoryRepository;
+import org.sitmun.domain.user.User;
 import org.sitmun.domain.user.UserRepository;
 import org.sitmun.infrastructure.util.TaskParameterUtil;
 import org.sitmun.infrastructure.variables.SystemVariableResolver;
@@ -87,8 +89,12 @@ public class ProxyConfigurationService {
     this.systemVariableResolver = systemVariableResolver;
   }
 
-  private static WmsPayloadDto getOgcWmsConfiguration(
-      Service service, ConfigProxyRequestDto configProxyRequestDto) {
+  private WmsPayloadDto getOgcWmsConfiguration(
+      Service service,
+      ConfigProxyRequestDto configProxyRequestDto,
+      User user,
+      Territory territory,
+      Application application) {
 
     if (service == null) {
       return null;
@@ -116,11 +122,16 @@ public class ProxyConfigurationService {
       if (DomainConstants.Proxy.PARAM_TYPE_VARY.equalsIgnoreCase(parameter.getType())) {
         varyParameters.add(parameter.getName());
       } else {
-        parameters.put(parameter.getName(), parameter.getValue());
+        final String resolvedValue =
+            systemVariableResolver.resolve(parameter.getValue(), user, territory, application);
+        parameters.put(parameter.getName(), resolvedValue);
       }
     }
+
+    final String resolvedUrl =
+        systemVariableResolver.resolve(service.getServiceURL(), user, territory, application);
     return WmsPayloadDto.builder()
-        .uri(service.getServiceURL())
+        .uri(resolvedUrl)
         .method(configProxyRequestDto.getMethod())
         .vary(varyParameters)
         .parameters(parameters)
@@ -333,7 +344,9 @@ public class ProxyConfigurationService {
           .findById(configProxyRequestDto.getTypeId())
           .ifPresent(
               service -> {
-                payload.set(getOgcWmsConfiguration(service, configProxyRequestDto));
+                payload.set(
+                    getOgcWmsConfiguration(
+                        service, configProxyRequestDto, user, territory, application));
                 configType.set(service.getType());
               });
     }

--- a/src/test/java/org/sitmun/authorization/proxy/service/ProxyConfigurationServiceTest.java
+++ b/src/test/java/org/sitmun/authorization/proxy/service/ProxyConfigurationServiceTest.java
@@ -262,10 +262,20 @@ class ProxyConfigurationServiceTest {
             .parameters(new HashMap<>())
             .build();
 
-    ServiceParameter fixedParam = mock(ServiceParameter.class);
-    when(fixedParam.getType()).thenReturn("FIXED");
-    when(fixedParam.getName()).thenReturn("env");
-    when(fixedParam.getValue()).thenReturn("munine:#{TERR_ID}");
+    ServiceParameter fixedParam1 = mock(ServiceParameter.class);
+    when(fixedParam1.getType()).thenReturn("FIXED");
+    when(fixedParam1.getName()).thenReturn("env1");
+    when(fixedParam1.getValue()).thenReturn("munine:#{TERR_ID}");
+
+    ServiceParameter fixedParam2 = mock(ServiceParameter.class);
+    when(fixedParam2.getType()).thenReturn("FIXED");
+    when(fixedParam2.getName()).thenReturn("env2");
+    when(fixedParam2.getValue()).thenReturn("#{TERR_ID}");
+
+    ServiceParameter fixedParam3 = mock(ServiceParameter.class);
+    when(fixedParam3.getType()).thenReturn("FIXED");
+    when(fixedParam3.getName()).thenReturn("env3");
+    when(fixedParam3.getValue()).thenReturn("TERR_ID");
 
     ServiceParameter varyParam = mock(ServiceParameter.class);
     when(varyParam.getType()).thenReturn("VARY");
@@ -274,8 +284,9 @@ class ProxyConfigurationServiceTest {
     Service mockService = mock(Service.class);
     when(mockService.getType()).thenReturn(TYPE_WMS);
     when(mockService.getPasswordSet()).thenReturn(false);
-    when(mockService.getServiceURL()).thenReturn("https://example.com/wms?ter=#{TERR_ID}");
-    when(mockService.getParameters()).thenReturn(new HashSet<>(Arrays.asList(fixedParam, varyParam)));
+    when(mockService.getServiceURL()).thenReturn("https://example.com/wms/#{TERR_ID}");
+    when(mockService.getParameters())
+        .thenReturn(new HashSet<>(Arrays.asList(fixedParam1, fixedParam2, fixedParam3, varyParam)));
 
     when(serviceRepository.findById(1)).thenReturn(Optional.of(mockService));
 
@@ -287,8 +298,10 @@ class ProxyConfigurationServiceTest {
     assertInstanceOf(WmsPayloadDto.class, result.getPayload());
 
     WmsPayloadDto payload = (WmsPayloadDto) result.getPayload();
-    assertEquals("https://example.com/wms?ter=99", payload.getUri());
-    assertEquals("munine:99", payload.getParameters().get("env"));
+    assertEquals("https://example.com/wms/99", payload.getUri());
+    assertEquals("munine:99", payload.getParameters().get("env1"));
+    assertEquals("99", payload.getParameters().get("env2"));
+    assertEquals("TERR_ID", payload.getParameters().get("env3"));
     assertEquals(List.of("layers"), payload.getVary());
   }
 

--- a/src/test/java/org/sitmun/authorization/proxy/service/ProxyConfigurationServiceTest.java
+++ b/src/test/java/org/sitmun/authorization/proxy/service/ProxyConfigurationServiceTest.java
@@ -241,6 +241,58 @@ class ProxyConfigurationServiceTest {
   }
 
   @Test
+  @DisplayName("getConfiguration resolves system variables in WMS service URL and fixed parameters")
+  void getConfigurationResolvesSystemVariablesInWmsServiceUrlAndFixedParameters() {
+    // Given
+    reset(systemVariableResolver);
+    when(systemVariableResolver.resolve(anyString(), any(), any(), any()))
+        .thenAnswer(
+            invocation -> {
+              String input = invocation.getArgument(0);
+              return input.replace("#{TERR_ID}", "99");
+            });
+
+    ConfigProxyRequestDto request =
+        ConfigProxyRequestDto.builder()
+            .appId(1)
+            .terId(1)
+            .type(TYPE_WMS)
+            .typeId(1)
+            .method("GET")
+            .parameters(new HashMap<>())
+            .build();
+
+    ServiceParameter fixedParam = mock(ServiceParameter.class);
+    when(fixedParam.getType()).thenReturn("FIXED");
+    when(fixedParam.getName()).thenReturn("env");
+    when(fixedParam.getValue()).thenReturn("munine:#{TERR_ID}");
+
+    ServiceParameter varyParam = mock(ServiceParameter.class);
+    when(varyParam.getType()).thenReturn("VARY");
+    when(varyParam.getName()).thenReturn("layers");
+
+    Service mockService = mock(Service.class);
+    when(mockService.getType()).thenReturn(TYPE_WMS);
+    when(mockService.getPasswordSet()).thenReturn(false);
+    when(mockService.getServiceURL()).thenReturn("https://example.com/wms?ter=#{TERR_ID}");
+    when(mockService.getParameters()).thenReturn(new HashSet<>(Arrays.asList(fixedParam, varyParam)));
+
+    when(serviceRepository.findById(1)).thenReturn(Optional.of(mockService));
+
+    // When
+    ConfigProxyDto result = service.getConfiguration(request, 0L, "testuser");
+
+    // Then
+    assertNotNull(result);
+    assertInstanceOf(WmsPayloadDto.class, result.getPayload());
+
+    WmsPayloadDto payload = (WmsPayloadDto) result.getPayload();
+    assertEquals("https://example.com/wms?ter=99", payload.getUri());
+    assertEquals("munine:99", payload.getParameters().get("env"));
+    assertEquals(List.of("layers"), payload.getVary());
+  }
+
+  @Test
   @DisplayName("getConfiguration handles null request parameters")
   void getConfigurationHandlesNullRequestParameters() {
     // Given


### PR DESCRIPTION
Allows system params to be replaced into parametrized service URLs. Example:

In service we use URL https://some.domain.com/geoserver/wms?env=munine:{TERR_COD}
We specify matching parameters:

<img width="1668" height="502" alt="image" src="https://github.com/user-attachments/assets/19d1be00-9f20-4bc9-810a-205dfe62a35a" />

Of course, the same is possible keeping the URL with no params and adding them directly into param config like so:

<img width="1673" height="608" alt="image" src="https://github.com/user-attachments/assets/e7203b09-74d6-4fff-88bd-31acb6ce116a" />

When the request goes through SITMUN's proxy, those params are properly replaced, in this case using the territory code in the actual geoserver request.

This replicates a SITMUN2 feature. I couldn't make it work with existing code, but it may exist. If that's the case I would appreciate indications on how to configure it from the administrator and a brief summary on how it works.

Thanks in advance