### PR TITLE
Cookie based tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ curl -X GET "http://localhost:8080/api/helpers/feature-type?url=http://example.c
 | `SPRING_DATASOURCE_PASSWORD`             | Database password | ``                                       | Yes (prod) |
 | `SITMUN_USER_SECRET`                     | JWT signing secret | Auto-generated                           | No |
 | `SITMUN_USER_TOKEN_VALIDITY_IN_MILLISECONDS` | JWT token validity in milliseconds | `36000000`                               | No |
-| `SITMUN_AUTHENTICATION_HTTP_ONLY_COOKIE` | HttpOnly flag for JWT cookie | `false`                                  | No |
+| `SITMUN_AUTHENTICATION_HTTP_ONLY_COOKIE` | HttpOnly flag for JWT cookie | `true`                                   | No |
 | `SITMUN_AUTHENTICATION_SAME_SITE_COOKIE` | SameSite attribute for JWT cookie | `Strict`                                 | No |
 | `SITMUN_PROXY_MIDDLEWARE_SECRET`         | Proxy middleware secret | Auto-generated                           | No |
 | `SITMUN_PROXY_MIDDLEWARE_TOKEN_VALIDITY_IN_MILLISECONDS` | Proxy token validity in milliseconds | `900000` (15 min)                        | No |

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ spring.profiles.active=prod
 | Endpoint | Method | Description | Access | Controller |
 | ---------- | --------- | ------------- | ---------- | ------------ |
 | `/api/authenticate` | POST | User authentication | Public | AuthenticationController |
+| `/api/authenticate/proxy` | POST | Generate short-lived proxy token | Authenticated | AuthenticationController |
 | `/api/account` | GET | User account management | Authenticated | UserController |
 | `/api/account/{id}` | GET | Get user by ID | Authenticated | UserController |
 | `/api/account/public/{id}` | GET | Get public user info | Public | UserController |
@@ -299,16 +300,39 @@ spring.profiles.active=prod
 #### Authentication
 
 ```bash
-# Login
+# Login - JWT is automatically set as an HTTP cookie
 curl -X POST http://localhost:8080/api/authenticate \
   -H "Content-Type: application/json" \
   -d '{"username":"admin","password":"admin"}'
 
-# Response
-{
-  "token": "eyJhbGciOiJIUzI1NiJ9..."
-}
+# The response sets the JWT token in an HTTP-only cookie named 'access_token'
+# Future requests will automatically include the cookie
 ```
+
+#### Using the Authentication Token
+
+Once authenticated, the JWT token is stored in the `access_token` cookie and automatically sent on requests:
+
+```bash
+# The cookie is automatically included by the browser/client
+# No need to manually add Authorization headers
+
+# The server validates the JWT token from the cookie
+```
+
+#### Proxy Authentication
+
+Generate a short-lived proxy token for the SITMUN Proxy Middleware:
+
+```bash
+# Requires user authentication (the access_token cookie is automatically included)
+curl -X POST http://localhost:8080/api/authenticate/proxy
+
+# The response sets a short-lived JWT token in the 'proxy_token' cookie
+# This token is used by proxy middleware
+```
+
+**Note:** The proxy token has a shorter expiration time (configured by `sitmun.proxy-middleware.token-validity-in-milliseconds`) than access token.
 
 #### Health Check
 
@@ -433,18 +457,22 @@ curl -X GET "http://localhost:8080/api/helpers/feature-type?url=http://example.c
 
 ### Environment Variables
 
-| Variable                                 | Description | Default                          | Required |
-| ---------------------------------------- | ------------- | ---------------------------------- | ---------- |
-| `SPRING_PROFILES_ACTIVE`                 | Active Spring profile | `dev`                            | No |
-| `SPRING_DATASOURCE_URL`                  | Database connection URL | H2 in-memory                     | Yes (prod) |
-| `SPRING_DATASOURCE_USERNAME`             | Database username | `sa`                             | Yes (prod) |
-| `SPRING_DATASOURCE_PASSWORD`             | Database password | ``                               | Yes (prod) |
-| `SITMUN_USER_SECRET`                     | JWT signing secret | Auto-generated                   | No |
-| `SITMUN_PROXY_MIDDLEWARE_SECRET`         | Proxy middleware secret | Auto-generated                   | No |
-| `SITMUN_FRONTEND_REDIRECTURL`            | Frontend callback URL for OIDC | `http://localhost:9000/viewer/callback` | If OIDC enabled |
-| `SITMUN_FRONTEND_REDIRECTURLVIEWER`      | Frontend callback URL for OIDC | `http://localhost:9000/viewer/callback` | If OIDC enabled |
+| Variable                                 | Description | Default                                  | Required |
+| ---------------------------------------- | ------------- |------------------------------------------| ---------- |
+| `SPRING_PROFILES_ACTIVE`                 | Active Spring profile | `dev`                                    | No |
+| `SPRING_DATASOURCE_URL`                  | Database connection URL | H2 in-memory                             | Yes (prod) |
+| `SPRING_DATASOURCE_USERNAME`             | Database username | `sa`                                     | Yes (prod) |
+| `SPRING_DATASOURCE_PASSWORD`             | Database password | ``                                       | Yes (prod) |
+| `SITMUN_USER_SECRET`                     | JWT signing secret | Auto-generated                           | No |
+| `SITMUN_USER_TOKEN_VALIDITY_IN_MILLISECONDS` | JWT token validity in milliseconds | `36000000`                               | No |
+| `SITMUN_AUTHENTICATION_HTTP_ONLY_COOKIE` | HttpOnly flag for JWT cookie | `false`                                  | No |
+| `SITMUN_AUTHENTICATION_SAME_SITE_COOKIE` | SameSite attribute for JWT cookie | `Strict`                                 | No |
+| `SITMUN_PROXY_MIDDLEWARE_SECRET`         | Proxy middleware secret | Auto-generated                           | No |
+| `SITMUN_PROXY_MIDDLEWARE_TOKEN_VALIDITY_IN_MILLISECONDS` | Proxy token validity in milliseconds | `900000` (15 min)                        | No |
+| `SITMUN_FRONTEND_REDIRECTURL`            | Frontend callback URL for OIDC | `http://localhost:9000/viewer/callback`  | If OIDC enabled |
+| `SITMUN_FRONTEND_REDIRECTURLVIEWER`      | Frontend callback URL for OIDC | `http://localhost:9000/viewer/callback`  | If OIDC enabled |
 | `SITMUN_FRONTEND_REDIRECTURLADMIN`       | Frontend callback URL for OIDC | `http://localhost:9000/admin/#/callback` | If OIDC enabled |
-| `SITMUN_AUTHENTICATION_OIDC_PROVIDERS_*` | Dynamic OIDC provider configuration | -                                | If OIDC enabled |
+| `SITMUN_AUTHENTICATION_OIDC_PROVIDERS_*` | Dynamic OIDC provider configuration | -                                        | If OIDC enabled |
 
 **Note:** OIDC providers are configured dynamically under `sitmun.authentication.oidc.providers.{providerId}`. See [OIDC Configuration](#oidcoauth2-configuration) for details.
 
@@ -479,8 +507,12 @@ sitmun:
   user:
     secret: ${SITMUN_USER_SECRET:auto-generated}
     token-validity-in-milliseconds: 36000000
+  authentication:
+    http-only-cookie: true
+    same-site-cookie: Strict
   proxy-middleware:
     secret: ${SITMUN_PROXY_MIDDLEWARE_SECRET:auto-generated}
+    token-validity-in-milliseconds: 900000
     config-response-validity-in-seconds: 3600
 ```
 
@@ -686,7 +718,8 @@ Comprehensive testing strategy:
 
 The application provides comprehensive security features:
 
-- **JWT Authentication**: Secure token-based authentication
+- **JWT Authentication**: Secure token-based authentication via HTTP-only cookies
+- **Cookie-Based Token Storage**: JWT tokens are stored in HTTP-only cookies for improved security
 - **Role-Based Access Control**: Fine-grained permission system
 - **Application Privacy**: Applications can be marked as private
 - **Public User Support**: Anonymous access with restrictions
@@ -700,8 +733,24 @@ The application provides comprehensive security features:
 sitmun:
   user:
     secret: ${SITMUN_USER_SECRET:auto-generated}
-    token-validity-in-milliseconds: 36000000
+    token-validity-in-milliseconds: 36000000  # JWT token lifetime in milliseconds (10 hours)
+  authentication:
+    http-only-cookie: true  # Whether to set HttpOnly flag on JWT cookie
+    same-site-cookie: Strict  # SameSite attribute for CSRF protection
 ```
+
+JWT tokens are stored in an HTTP-only cookie (`access_token`) that is automatically set during authentication. The cookie's `max-age` is automatically derived from `token-validity-in-milliseconds` to keep both values synchronized. The `http-only-cookie` setting controls whether the cookie can be accessed by JavaScript.
+
+#### Proxy Token Configuration
+
+```yaml
+sitmun:
+  proxy-middleware:
+    secret: ${SITMUN_PROXY_MIDDLEWARE_SECRET:auto-generated}
+    token-validity-in-milliseconds: 900000  # Proxy token lifetime (15 minutes default)
+```
+
+The proxy token is a short-lived JWT token generated via the `/api/authenticate/proxy` endpoint for secure communication between the Backend Core and Proxy Middleware. It is stored in the `proxy_token` cookie and automatically included in requests to the Proxy Middleware. The token has a much shorter lifetime than the regular access token for additional security.
 
 #### LDAP Configuration
 
@@ -855,7 +904,7 @@ const mapViewerConfig = {
     baseUrl: 'http://localhost:8080/api',
     authentication: {
       endpoint: '/authenticate',
-      tokenStorage: 'localStorage'
+      cookieStorage: 'access_token'
     }
   },
   applications: {

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ spring.profiles.active=prod
 | `/api/helpers/capabilities` | GET | Extract service capabilities | Admin | ServiceCapabilitiesExtractorController |
 | `/api/helpers/feature-type` | GET | Extract feature type info | Admin | FeatureTypeExtractorController |
 | `/swagger-ui/index.html` | GET | API documentation | Public | OpenAPI |
+| `/api/logout` | POST | Logout user and clear authentication cookie | Authenticated | AuthenticationController |
 
 ### Usage Examples
 
@@ -399,6 +400,14 @@ curl -X GET "http://localhost:8080/api/helpers/capabilities?url=http://example.c
 
 # Extract feature type information
 curl -X GET "http://localhost:8080/api/helpers/feature-type?url=http://example.com/wfs"
+```
+
+#### Logout
+
+```bash
+# Logout - clears the authentication cookie and invalidates the session
+curl -X POST http://localhost:8080/api/logout
+
 ```
 
 ### Request Parameters

--- a/src/main/java/org/sitmun/authentication/controller/AuthenticationController.java
+++ b/src/main/java/org/sitmun/authentication/controller/AuthenticationController.java
@@ -2,9 +2,11 @@ package org.sitmun.authentication.controller;
 
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import java.util.Date;
 import java.util.Optional;
 import org.sitmun.authentication.dto.AuthenticationResponse;
 import org.sitmun.authentication.dto.UserPasswordAuthenticationRequest;
@@ -12,6 +14,7 @@ import org.sitmun.authentication.service.CookieService;
 import org.sitmun.domain.user.User;
 import org.sitmun.domain.user.UserRepository;
 import org.sitmun.infrastructure.security.service.JsonWebTokenService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -32,6 +35,12 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "authentication", description = "authentication with JWT")
 @Validated
 public class AuthenticationController {
+
+  public static final String ACCESS_TOKEN_COOKIE_NAME = "access_token";
+  public static final String PROXY_TOKEN_COOKIE_NAME = "proxy_token";
+
+  @Value("${sitmun.proxy-middleware.token-validity-in-milliseconds}")
+  private int validity;
 
   private final AuthenticationManager authenticationManager;
 
@@ -61,7 +70,7 @@ public class AuthenticationController {
   }
 
   /**
-   * Authenticate a user an obtain a JWT token.
+   * Authenticate a user and obtain a JWT token.
    *
    * @param body user login and password
    * @return JWT token
@@ -85,9 +94,25 @@ public class AuthenticationController {
       String token =
           jsonWebTokenService.generateToken(userDetails, user.get().getLastPasswordChange());
 
-      response.addCookie(cookieService.createJwtCookie(token, request.isSecure()));
+      final Cookie cookie = new Cookie(ACCESS_TOKEN_COOKIE_NAME, token);
+      response.addCookie(
+          cookieService.customizeAccessTokenCookie(cookie, request.isSecure(), null));
       return ResponseEntity.status(HttpStatus.OK).build();
     }
     return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+  }
+
+  @PostMapping("/proxy")
+  public ResponseEntity<AuthenticationResponse> authenticateProxy(
+      Authentication authentication, HttpServletRequest request, HttpServletResponse response) {
+    final String username = authentication.getName();
+
+    final String shortLivedToken =
+        jsonWebTokenService.generateToken(username, new Date(), validity);
+    final Cookie cookie = new Cookie(PROXY_TOKEN_COOKIE_NAME, shortLivedToken);
+
+    response.addCookie(
+        cookieService.customizeAccessTokenCookie(cookie, request.isSecure(), validity / 1000));
+    return ResponseEntity.status(HttpStatus.OK).build();
   }
 }

--- a/src/main/java/org/sitmun/authentication/controller/AuthenticationController.java
+++ b/src/main/java/org/sitmun/authentication/controller/AuthenticationController.java
@@ -2,10 +2,12 @@ package org.sitmun.authentication.controller;
 
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import java.util.Optional;
 import org.sitmun.authentication.dto.AuthenticationResponse;
 import org.sitmun.authentication.dto.UserPasswordAuthenticationRequest;
+import org.sitmun.authentication.service.CookieService;
 import org.sitmun.domain.user.User;
 import org.sitmun.domain.user.UserRepository;
 import org.sitmun.infrastructure.security.service.JsonWebTokenService;
@@ -22,6 +24,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
 
 /** Controller to authenticate users. */
 @RestController
@@ -40,17 +44,21 @@ public class AuthenticationController {
 
   private final JsonWebTokenService jsonWebTokenService;
 
+  private final CookieService cookieService;
+
   public AuthenticationController(
       AuthenticationManager authenticationManager,
       UserDetailsService userDetailsService,
       PasswordEncoder encoder,
       JsonWebTokenService jsonWebTokenService,
-      UserRepository userRepository) {
+      UserRepository userRepository,
+      CookieService cookieService) {
     this.authenticationManager = authenticationManager;
     this.userDetailsService = userDetailsService;
     this.encoder = encoder;
     this.jsonWebTokenService = jsonWebTokenService;
     this.userRepository = userRepository;
+    this.cookieService = cookieService;
   }
 
   /**
@@ -62,7 +70,9 @@ public class AuthenticationController {
   @PostMapping
   @SecurityRequirements
   public ResponseEntity<AuthenticationResponse> authenticateUser(
-      @Valid @RequestBody UserPasswordAuthenticationRequest body) {
+      @Valid @RequestBody UserPasswordAuthenticationRequest body,
+      HttpServletRequest request,
+      HttpServletResponse response) {
     Authentication authentication =
         authenticationManager.authenticate(
             new UsernamePasswordAuthenticationToken(body.getUsername(), body.getPassword()));
@@ -76,7 +86,8 @@ public class AuthenticationController {
       String token =
           jsonWebTokenService.generateToken(userDetails, user.get().getLastPasswordChange());
 
-      return ResponseEntity.ok().body(new AuthenticationResponse(token));
+      response.addCookie(cookieService.createJwtCookie(token, request.isSecure()));
+      return ResponseEntity.status(HttpStatus.OK).build();
     }
     return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
   }

--- a/src/main/java/org/sitmun/authentication/controller/AuthenticationController.java
+++ b/src/main/java/org/sitmun/authentication/controller/AuthenticationController.java
@@ -6,8 +6,6 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import java.util.Date;
-import java.util.Optional;
 import org.sitmun.authentication.dto.AuthenticationResponse;
 import org.sitmun.authentication.dto.UserPasswordAuthenticationRequest;
 import org.sitmun.authentication.service.CookieService;
@@ -22,12 +20,14 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Date;
+import java.util.Optional;
 
 /** Controller to authenticate users. */
 @RestController
@@ -37,7 +37,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthenticationController {
 
   public static final String ACCESS_TOKEN_COOKIE_NAME = "access_token";
-  public static final String PROXY_TOKEN_COOKIE_NAME = "proxy_token";
 
   @Value("${sitmun.proxy-middleware.token-validity-in-milliseconds}")
   private int validity;
@@ -48,7 +47,6 @@ public class AuthenticationController {
 
   private final UserRepository userRepository;
 
-  private final PasswordEncoder encoder;
 
   private final JsonWebTokenService jsonWebTokenService;
 
@@ -57,13 +55,11 @@ public class AuthenticationController {
   public AuthenticationController(
       AuthenticationManager authenticationManager,
       UserDetailsService userDetailsService,
-      PasswordEncoder encoder,
       JsonWebTokenService jsonWebTokenService,
       UserRepository userRepository,
       CookieService cookieService) {
     this.authenticationManager = authenticationManager;
     this.userDetailsService = userDetailsService;
-    this.encoder = encoder;
     this.jsonWebTokenService = jsonWebTokenService;
     this.userRepository = userRepository;
     this.cookieService = cookieService;
@@ -95,24 +91,31 @@ public class AuthenticationController {
           jsonWebTokenService.generateToken(userDetails, user.get().getLastPasswordChange());
 
       final Cookie cookie = new Cookie(ACCESS_TOKEN_COOKIE_NAME, token);
-      response.addCookie(
-          cookieService.customizeAccessTokenCookie(cookie, request.isSecure(), null));
+      cookieService.customizeAccessTokenCookie(cookie, request.isSecure(), null);
+      response.addCookie(cookie);
       return ResponseEntity.status(HttpStatus.OK).build();
     }
     return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
   }
 
   @PostMapping("/proxy")
-  public ResponseEntity<AuthenticationResponse> authenticateProxy(
-      Authentication authentication, HttpServletRequest request, HttpServletResponse response) {
+  public ResponseEntity<AuthenticationResponse> authenticateProxy(Authentication authentication) {
     final String username = authentication.getName();
 
     final String shortLivedToken =
         jsonWebTokenService.generateToken(username, new Date(), validity);
-    final Cookie cookie = new Cookie(PROXY_TOKEN_COOKIE_NAME, shortLivedToken);
 
-    response.addCookie(
-        cookieService.customizeAccessTokenCookie(cookie, request.isSecure(), validity / 1000));
+    AuthenticationResponse authResponse = new AuthenticationResponse();
+    authResponse.setProxyToken(shortLivedToken);
+
+    return ResponseEntity.status(HttpStatus.OK).body(authResponse);
+  }
+
+  @PostMapping("/logout")
+  public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+    final Cookie cookie = new Cookie(ACCESS_TOKEN_COOKIE_NAME, null);
+    cookieService.customizeAccessTokenCookie(cookie, request.isSecure(), 0);
+    response.addCookie(cookie);
     return ResponseEntity.status(HttpStatus.OK).build();
   }
 }

--- a/src/main/java/org/sitmun/authentication/controller/AuthenticationController.java
+++ b/src/main/java/org/sitmun/authentication/controller/AuthenticationController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import java.util.Optional;
 import org.sitmun.authentication.dto.AuthenticationResponse;
 import org.sitmun.authentication.dto.UserPasswordAuthenticationRequest;
 import org.sitmun.authentication.service.CookieService;
@@ -24,8 +25,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.Optional;
 
 /** Controller to authenticate users. */
 @RestController

--- a/src/main/java/org/sitmun/authentication/dto/AuthenticationResponse.java
+++ b/src/main/java/org/sitmun/authentication/dto/AuthenticationResponse.java
@@ -1,23 +1,11 @@
 package org.sitmun.authentication.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
 
+@Data
 public class AuthenticationResponse {
 
-  private String idToken;
-
-  public AuthenticationResponse() {}
-
-  public AuthenticationResponse(String idToken) {
-    this.idToken = idToken;
-  }
-
-  @JsonProperty("id_token")
-  public String getIdToken() {
-    return idToken;
-  }
-
-  void setIdToken(String idToken) {
-    this.idToken = idToken;
-  }
+  @JsonProperty("proxy_token")
+  private String proxyToken;
 }

--- a/src/main/java/org/sitmun/authentication/handler/OidcAuthenticationSuccessHandler.java
+++ b/src/main/java/org/sitmun/authentication/handler/OidcAuthenticationSuccessHandler.java
@@ -1,17 +1,15 @@
 package org.sitmun.authentication.handler;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.sitmun.authentication.service.CookieService;
 import org.sitmun.authentication.service.OidcRedirectService;
 import org.sitmun.domain.user.User;
 import org.sitmun.domain.user.UserRepository;
 import org.sitmun.infrastructure.config.Profiles;
 import org.sitmun.infrastructure.security.service.JsonWebTokenService;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -23,6 +21,8 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationSu
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
+import java.io.IOException;
+
 /**
  * Handler for successful OIDC authentication. Obtains user from database and generates JWT token.
  */
@@ -32,24 +32,11 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class OidcAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-  public static final String OIDC_TOKEN_COOKIE_NAME = "oidc_token";
-
   private final UserRepository userRepository;
   private final OidcRedirectService redirectService;
   private final UserDetailsService userDetailsService;
   private final JsonWebTokenService jsonWebTokenService;
-
-  /**
-   * Controls the {@code HttpOnly} flag on the {@code oidc_token} cookie. When {@code false}
-   * (default), the cookie is accessible to frontend JavaScript via {@code document.cookie} /
-   * cookie-service libraries. When {@code true}, the browser hides the cookie from JavaScript (XSS
-   * mitigation), but current frontends cannot read the token. A future improvement will replace
-   * cookie transfer with a URL fragment, making {@code true} the safe default.
-   *
-   * @see <a href="README.md">OIDC Configuration — Current limitation and future improvement</a>
-   */
-  @Value("${sitmun.authentication.oidc.http-only-cookie:false}")
-  private Boolean oidcCookieHttpOnly;
+  private final CookieService cookieService;
 
   @Override
   public void onAuthenticationSuccess(
@@ -75,13 +62,7 @@ public class OidcAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuc
       final String jwtToken =
           jsonWebTokenService.generateToken(userDetails, user.getLastPasswordChange());
 
-      final Cookie jwtCookie = new Cookie(OIDC_TOKEN_COOKIE_NAME, jwtToken);
-      jwtCookie.setHttpOnly(oidcCookieHttpOnly);
-      jwtCookie.setSecure(request.isSecure());
-      jwtCookie.setPath("/");
-      jwtCookie.setMaxAge(3600);
-
-      response.addCookie(jwtCookie);
+      response.addCookie(cookieService.createJwtCookie(jwtToken, request.isSecure()));
     } catch (Exception e) {
       log.error("OIDC authentication processing failed", e);
       log.error("Error message: {}", e.getMessage());

--- a/src/main/java/org/sitmun/authentication/handler/OidcAuthenticationSuccessHandler.java
+++ b/src/main/java/org/sitmun/authentication/handler/OidcAuthenticationSuccessHandler.java
@@ -68,9 +68,10 @@ public class OidcAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuc
       final String jwtToken =
           jsonWebTokenService.generateToken(userDetails, user.getLastPasswordChange());
 
-      response.addCookie(
-          cookieService.customizeAccessTokenCookie(
-              new Cookie(ACCESS_TOKEN_COOKIE_NAME, jwtToken), request.isSecure(), validity));
+      final Cookie cookie =  new Cookie(ACCESS_TOKEN_COOKIE_NAME, jwtToken);
+      cookieService.customizeAccessTokenCookie(cookie, request.isSecure(), validity);
+
+      response.addCookie(cookie);
     } catch (Exception e) {
       log.error("OIDC authentication processing failed", e);
       log.error("Error message: {}", e.getMessage());

--- a/src/main/java/org/sitmun/authentication/handler/OidcAuthenticationSuccessHandler.java
+++ b/src/main/java/org/sitmun/authentication/handler/OidcAuthenticationSuccessHandler.java
@@ -2,6 +2,7 @@ package org.sitmun.authentication.handler;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sitmun.authentication.service.CookieService;
@@ -20,8 +21,6 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
-
-import java.io.IOException;
 
 /**
  * Handler for successful OIDC authentication. Obtains user from database and generates JWT token.

--- a/src/main/java/org/sitmun/authentication/handler/OidcAuthenticationSuccessHandler.java
+++ b/src/main/java/org/sitmun/authentication/handler/OidcAuthenticationSuccessHandler.java
@@ -1,5 +1,8 @@
 package org.sitmun.authentication.handler;
 
+import static org.sitmun.authentication.controller.AuthenticationController.ACCESS_TOKEN_COOKIE_NAME;
+
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -11,6 +14,7 @@ import org.sitmun.domain.user.User;
 import org.sitmun.domain.user.UserRepository;
 import org.sitmun.infrastructure.config.Profiles;
 import org.sitmun.infrastructure.security.service.JsonWebTokenService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -30,6 +34,9 @@ import org.springframework.util.StringUtils;
 @Component
 @RequiredArgsConstructor
 public class OidcAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+  @Value("${sitmun.user.token-validity-in-milliseconds:36000000}")
+  private int validity;
 
   private final UserRepository userRepository;
   private final OidcRedirectService redirectService;
@@ -61,7 +68,9 @@ public class OidcAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuc
       final String jwtToken =
           jsonWebTokenService.generateToken(userDetails, user.getLastPasswordChange());
 
-      response.addCookie(cookieService.createJwtCookie(jwtToken, request.isSecure()));
+      response.addCookie(
+          cookieService.customizeAccessTokenCookie(
+              new Cookie(ACCESS_TOKEN_COOKIE_NAME, jwtToken), request.isSecure(), validity));
     } catch (Exception e) {
       log.error("OIDC authentication processing failed", e);
       log.error("Error message: {}", e.getMessage());

--- a/src/main/java/org/sitmun/authentication/service/CookieService.java
+++ b/src/main/java/org/sitmun/authentication/service/CookieService.java
@@ -16,18 +16,16 @@ public class CookieService {
   @Value("${sitmun.authentication.same-site-cookie:Strict}")
   private String sameSiteCookie;
 
-  public Cookie customizeAccessTokenCookie(Cookie cookie, boolean isSecure, Integer maxAge) {
-    return addCookieConfig(
+  public void customizeAccessTokenCookie(Cookie cookie, boolean isSecure, Integer maxAge) {
+    addCookieConfig(
         cookie, isSecure, maxAge != null ? maxAge : tokenValidityInMillis / 1000);
   }
 
-  public Cookie addCookieConfig(Cookie cookie, boolean isSecure, int maxAge) {
+  public void addCookieConfig(Cookie cookie, boolean isSecure, int maxAge) {
     cookie.setHttpOnly(tokenCookieHttpOnly);
     cookie.setSecure(isSecure);
     cookie.setPath("/");
     cookie.setAttribute("SameSite", sameSiteCookie);
     cookie.setMaxAge(maxAge);
-
-    return cookie;
   }
 }

--- a/src/main/java/org/sitmun/authentication/service/CookieService.java
+++ b/src/main/java/org/sitmun/authentication/service/CookieService.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class CookieService {
 
-  @Value("${sitmun.authentication.http-only-cookie:false}")
+  @Value("${sitmun.authentication.http-only-cookie:true}")
   private Boolean tokenCookieHttpOnly;
 
   @Value("${sitmun.user.token-validity-in-milliseconds:36000000}")

--- a/src/main/java/org/sitmun/authentication/service/CookieService.java
+++ b/src/main/java/org/sitmun/authentication/service/CookieService.java
@@ -1,0 +1,31 @@
+package org.sitmun.authentication.service;
+
+import jakarta.servlet.http.Cookie;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CookieService {
+
+  @Value("${sitmun.authentication.http-only-cookie:false}")
+  private Boolean tokenCookieHttpOnly;
+
+  @Value("${sitmun.authentication.access-token-max-age:3600}")
+  private int accessTokenMaxAge;
+
+  @Value("${sitmun.authentication.same-site-cookie:Strict}")
+  private String sameSiteCookie;
+
+  public static final String OIDC_TOKEN_COOKIE_NAME = "jwt_token";
+
+  public Cookie createJwtCookie(String jwtToken, boolean isSecure) {
+    final Cookie jwtCookie = new Cookie(OIDC_TOKEN_COOKIE_NAME, jwtToken);
+    jwtCookie.setHttpOnly(tokenCookieHttpOnly);
+    jwtCookie.setSecure(isSecure);
+    jwtCookie.setPath("/");
+    jwtCookie.setMaxAge(accessTokenMaxAge);
+    jwtCookie.setAttribute("SameSite", sameSiteCookie);
+
+    return jwtCookie;
+  }
+}

--- a/src/main/java/org/sitmun/authentication/service/CookieService.java
+++ b/src/main/java/org/sitmun/authentication/service/CookieService.java
@@ -10,22 +10,24 @@ public class CookieService {
   @Value("${sitmun.authentication.http-only-cookie:false}")
   private Boolean tokenCookieHttpOnly;
 
-  @Value("${sitmun.authentication.access-token-max-age:3600}")
-  private int accessTokenMaxAge;
+  @Value("${sitmun.user.token-validity-in-milliseconds:36000000}")
+  private int tokenValidityInMillis;
 
   @Value("${sitmun.authentication.same-site-cookie:Strict}")
   private String sameSiteCookie;
 
-  public static final String OIDC_TOKEN_COOKIE_NAME = "jwt_token";
+  public Cookie customizeAccessTokenCookie(Cookie cookie, boolean isSecure, Integer maxAge) {
+    return addCookieConfig(
+        cookie, isSecure, maxAge != null ? maxAge : tokenValidityInMillis / 1000);
+  }
 
-  public Cookie createJwtCookie(String jwtToken, boolean isSecure) {
-    final Cookie jwtCookie = new Cookie(OIDC_TOKEN_COOKIE_NAME, jwtToken);
-    jwtCookie.setHttpOnly(tokenCookieHttpOnly);
-    jwtCookie.setSecure(isSecure);
-    jwtCookie.setPath("/");
-    jwtCookie.setMaxAge(accessTokenMaxAge);
-    jwtCookie.setAttribute("SameSite", sameSiteCookie);
+  public Cookie addCookieConfig(Cookie cookie, boolean isSecure, int maxAge) {
+    cookie.setHttpOnly(tokenCookieHttpOnly);
+    cookie.setSecure(isSecure);
+    cookie.setPath("/");
+    cookie.setAttribute("SameSite", sameSiteCookie);
+    cookie.setMaxAge(maxAge);
 
-    return jwtCookie;
+    return cookie;
   }
 }

--- a/src/main/java/org/sitmun/authorization/proxy/controllers/ProxyConfigurationController.java
+++ b/src/main/java/org/sitmun/authorization/proxy/controllers/ProxyConfigurationController.java
@@ -62,7 +62,7 @@ public class ProxyConfigurationController {
       log.info("Token identifies user {} with expiration time {}", username, expirationTime);
     } else {
       username = SecurityConstants.PUBLIC_PRINCIPAL;
-      log.info("No token identifies user {} with expiration time {}", username, expirationTime);
+      log.debug("Resolved public principal={}", username);
     }
     if (proxyConfigurationService.validateUserAccess(configProxyRequestDto, username)) {
       log.info("User {} is authorized to access the requested configuration", username);

--- a/src/main/java/org/sitmun/authorization/proxy/controllers/ProxyConfigurationController.java
+++ b/src/main/java/org/sitmun/authorization/proxy/controllers/ProxyConfigurationController.java
@@ -59,10 +59,10 @@ public class ProxyConfigurationController {
         log.error("JWT is invalid for user {}", username);
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
       }
-      log.debug("JWT resolved principal={} expMs={}", username, expirationTime);
+      log.info("Token identifies user {} with expiration time {}", username, expirationTime);
     } else {
       username = SecurityConstants.PUBLIC_PRINCIPAL;
-      log.debug("Resolved public principal={}", username);
+      log.info("No token identifies user {} with expiration time {}", username, expirationTime);
     }
     if (proxyConfigurationService.validateUserAccess(configProxyRequestDto, username)) {
       log.info("User {} is authorized to access the requested configuration", username);

--- a/src/main/java/org/sitmun/infrastructure/security/filter/JsonWebTokenFilter.java
+++ b/src/main/java/org/sitmun/infrastructure/security/filter/JsonWebTokenFilter.java
@@ -3,16 +3,18 @@ package org.sitmun.infrastructure.security.filter;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
+import org.sitmun.authentication.service.CookieService;
 import org.sitmun.domain.user.User;
 import org.sitmun.domain.user.UserRepository;
 import org.sitmun.infrastructure.security.service.JsonWebTokenService;
-import org.springframework.http.HttpHeaders;
 import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -42,14 +44,14 @@ public class JsonWebTokenFilter extends OncePerRequestFilter {
       @NonNull HttpServletResponse httpServletResponse,
       @NonNull FilterChain filterChain)
       throws ServletException, IOException {
-    final String requestTokenHeader = httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION);
-    if (StringUtils.isEmpty(requestTokenHeader)
-        || !StringUtils.startsWith(requestTokenHeader, "Bearer ")) {
+    final String jwtToken = getTokenFromRequest(httpServletRequest);
+
+    if (StringUtils.isEmpty(jwtToken)) {
       filterChain.doFilter(httpServletRequest, httpServletResponse);
       return;
     }
+
     try {
-      String jwtToken = requestTokenHeader.substring(7);
       String username = jsonWebTokenService.getUsernameFromToken(jwtToken);
       if (StringUtils.isNotEmpty(username)
           && SecurityContextHolder.getContext().getAuthentication() == null) {
@@ -77,5 +79,13 @@ public class JsonWebTokenFilter extends OncePerRequestFilter {
       logger.error(e.getMessage(), e);
     }
     filterChain.doFilter(httpServletRequest, httpServletResponse);
+  }
+
+  private String getTokenFromRequest(HttpServletRequest request) {
+    return Arrays.stream(request.getCookies())
+        .filter(c -> CookieService.OIDC_TOKEN_COOKIE_NAME.equals(c.getName()))
+        .findFirst()
+        .map(Cookie::getValue)
+        .orElse(null);
   }
 }

--- a/src/main/java/org/sitmun/infrastructure/security/filter/JsonWebTokenFilter.java
+++ b/src/main/java/org/sitmun/infrastructure/security/filter/JsonWebTokenFilter.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
-import org.sitmun.authentication.service.CookieService;
+import org.sitmun.authentication.controller.AuthenticationController;
 import org.sitmun.domain.user.User;
 import org.sitmun.domain.user.UserRepository;
 import org.sitmun.infrastructure.security.service.JsonWebTokenService;
@@ -82,8 +82,11 @@ public class JsonWebTokenFilter extends OncePerRequestFilter {
   }
 
   private String getTokenFromRequest(HttpServletRequest request) {
+    if (request.getCookies() == null) {
+      return null;
+    }
     return Arrays.stream(request.getCookies())
-        .filter(c -> CookieService.OIDC_TOKEN_COOKIE_NAME.equals(c.getName()))
+        .filter(c -> AuthenticationController.ACCESS_TOKEN_COOKIE_NAME.equals(c.getName()))
         .findFirst()
         .map(Cookie::getValue)
         .orElse(null);

--- a/src/main/java/org/sitmun/infrastructure/security/service/JsonWebTokenService.java
+++ b/src/main/java/org/sitmun/infrastructure/security/service/JsonWebTokenService.java
@@ -27,18 +27,22 @@ public class JsonWebTokenService {
   private SecretKey key;
 
   public String generateToken(UserDetails userDetails, Date lastPasswordChange) {
-    return generateToken(userDetails.getUsername(), new Date(), lastPasswordChange);
+    return generateToken(userDetails.getUsername(), new Date(), lastPasswordChange, validity);
   }
 
   public String generateToken(UserDetails userDetails) {
-    return generateToken(userDetails.getUsername(), new Date(), null);
+    return generateToken(userDetails.getUsername(), new Date(), null, validity);
   }
 
   public String generateToken(String username, Date date) {
-    return generateToken(username, date, null);
+    return generateToken(username, date, null, validity);
   }
 
-  public String generateToken(String username, Date date, Date lastPasswordChange) {
+  public String generateToken(String username, Date date, int validity) {
+    return generateToken(username, date, null, validity);
+  }
+
+  public String generateToken(String username, Date date, Date lastPasswordChange, int validity) {
 
     long currentTimeMillis = date.getTime();
     JwtBuilder builder =

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -173,6 +173,23 @@
       "type": "java.lang.Boolean",
       "description": "Check code lists on startup.",
       "defaultValue": true
+    },
+    {
+      "name": "sitmun.proxy-middleware.token-validity-in-milliseconds",
+      "type": "java.lang.Long",
+      "description": "Token validity duration for proxy middleware in milliseconds.",
+      "defaultValue": 900000
+    },
+    {
+      "name": "sitmun.authentication.oidc.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable or disable OIDC authentication.",
+      "defaultValue": false
+    },
+    {
+      "name": "sitmun.authentication.oidc.providers",
+      "type": "java.util.Map<java.lang.String, java.lang.Object>",
+      "description": "OIDC providers configuration."
     }
   ],
   "hints": [
@@ -199,4 +216,4 @@
       ]
     }
   ]
-} 
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,13 +76,13 @@ sitmun:
   proxy-middleware:
     secret: 9ef80c644166846897f6a87d3cf6ab204d144229
     config-response-validity-in-seconds: 3600
+    token-validity-in-milliseconds: 900000
     force: false
     url: http://localhost:8080/middleware
     # When enabled, validates user permissions and enforces role-based access control
     validate-user-access: true
   authentication:
-    http-only-cookie: false
-    access-token-max-age: 3600
+    http-only-cookie: true
     same-site-cookie: Strict
     oidc:
       enabled: ${SITMUN_AUTH_OIDC_ENABLED:false}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,6 +81,9 @@ sitmun:
     # When enabled, validates user permissions and enforces role-based access control
     validate-user-access: true
   authentication:
+    http-only-cookie: false
+    access-token-max-age: 3600
+    same-site-cookie: Strict
     oidc:
       enabled: ${SITMUN_AUTH_OIDC_ENABLED:false}
       providers: { }

--- a/src/test/java/org/sitmun/administration/controller/FeatureTypeExtractorControllerTest.java
+++ b/src/test/java/org/sitmun/administration/controller/FeatureTypeExtractorControllerTest.java
@@ -86,6 +86,6 @@ class FeatureTypeExtractorControllerTest extends BaseTest {
     mvc.perform(get(URI_TEMPLATE, "https://fake"))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.success").value(false))
-        .andExpect(jsonPath("$.reason", Matchers.startsWith("UnknownHostException: fake")));
+        .andExpect(jsonPath("$.reason", Matchers.startsWith("UnknownHostException: Host desconocido (fake)")));
   }
 }

--- a/src/test/java/org/sitmun/authentication/controller/AuthenticationControllerLdapEnabledTest.java
+++ b/src/test/java/org/sitmun/authentication/controller/AuthenticationControllerLdapEnabledTest.java
@@ -1,7 +1,8 @@
 package org.sitmun.authentication.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.unboundid.ldap.listener.InMemoryDirectoryServer;
 import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
@@ -13,7 +14,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.sitmun.authentication.dto.UserPasswordAuthenticationRequest;
-import org.sitmun.authentication.service.CookieService;
 import org.sitmun.infrastructure.config.Profiles;
 import org.sitmun.test.AdditiveActiveProfiles;
 import org.sitmun.test.TestUtils;
@@ -74,7 +74,7 @@ class AuthenticationControllerLdapEnabledTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(TestUtils.asJsonString(login)))
         .andExpect(status().isOk())
-        .andExpect(cookie().exists(CookieService.OIDC_TOKEN_COOKIE_NAME));
+        .andExpect(cookie().exists(AuthenticationController.ACCESS_TOKEN_COOKIE_NAME));
   }
 
   @Test
@@ -89,7 +89,7 @@ class AuthenticationControllerLdapEnabledTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(TestUtils.asJsonString(login)))
         .andExpect(status().isOk())
-        .andExpect(cookie().exists(CookieService.OIDC_TOKEN_COOKIE_NAME));
+        .andExpect(cookie().exists(AuthenticationController.ACCESS_TOKEN_COOKIE_NAME));
   }
 
   @Test

--- a/src/test/java/org/sitmun/authentication/controller/AuthenticationControllerLdapEnabledTest.java
+++ b/src/test/java/org/sitmun/authentication/controller/AuthenticationControllerLdapEnabledTest.java
@@ -1,8 +1,7 @@
 package org.sitmun.authentication.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.unboundid.ldap.listener.InMemoryDirectoryServer;
 import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
@@ -14,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.sitmun.authentication.dto.UserPasswordAuthenticationRequest;
+import org.sitmun.authentication.service.CookieService;
 import org.sitmun.infrastructure.config.Profiles;
 import org.sitmun.test.AdditiveActiveProfiles;
 import org.sitmun.test.TestUtils;
@@ -74,7 +74,7 @@ class AuthenticationControllerLdapEnabledTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(TestUtils.asJsonString(login)))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.id_token").exists());
+        .andExpect(cookie().exists(CookieService.OIDC_TOKEN_COOKIE_NAME));
   }
 
   @Test
@@ -89,7 +89,7 @@ class AuthenticationControllerLdapEnabledTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(TestUtils.asJsonString(login)))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.id_token").exists());
+        .andExpect(cookie().exists(CookieService.OIDC_TOKEN_COOKIE_NAME));
   }
 
   @Test

--- a/src/test/java/org/sitmun/authentication/controller/AuthenticationControllerLdapMailTest.java
+++ b/src/test/java/org/sitmun/authentication/controller/AuthenticationControllerLdapMailTest.java
@@ -74,6 +74,6 @@ class AuthenticationControllerLdapMailTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(TestUtils.asJsonString(login)))
         .andExpect(status().isOk())
-      .andExpect(cookie().exists(CookieService.OIDC_TOKEN_COOKIE_NAME));
+        .andExpect(cookie().exists(CookieService.OIDC_TOKEN_COOKIE_NAME));
   }
 }

--- a/src/test/java/org/sitmun/authentication/controller/AuthenticationControllerLdapMailTest.java
+++ b/src/test/java/org/sitmun/authentication/controller/AuthenticationControllerLdapMailTest.java
@@ -1,7 +1,8 @@
 package org.sitmun.authentication.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.unboundid.ldap.listener.InMemoryDirectoryServer;
 import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
@@ -13,7 +14,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.sitmun.authentication.dto.UserPasswordAuthenticationRequest;
-import org.sitmun.authentication.service.CookieService;
 import org.sitmun.infrastructure.config.Profiles;
 import org.sitmun.test.AdditiveActiveProfiles;
 import org.sitmun.test.TestUtils;
@@ -74,6 +74,6 @@ class AuthenticationControllerLdapMailTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(TestUtils.asJsonString(login)))
         .andExpect(status().isOk())
-        .andExpect(cookie().exists(CookieService.OIDC_TOKEN_COOKIE_NAME));
+        .andExpect(cookie().exists(AuthenticationController.ACCESS_TOKEN_COOKIE_NAME));
   }
 }

--- a/src/test/java/org/sitmun/authentication/controller/AuthenticationControllerLdapMailTest.java
+++ b/src/test/java/org/sitmun/authentication/controller/AuthenticationControllerLdapMailTest.java
@@ -1,8 +1,7 @@
 package org.sitmun.authentication.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.unboundid.ldap.listener.InMemoryDirectoryServer;
 import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
@@ -14,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.sitmun.authentication.dto.UserPasswordAuthenticationRequest;
+import org.sitmun.authentication.service.CookieService;
 import org.sitmun.infrastructure.config.Profiles;
 import org.sitmun.test.AdditiveActiveProfiles;
 import org.sitmun.test.TestUtils;
@@ -74,6 +74,6 @@ class AuthenticationControllerLdapMailTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(TestUtils.asJsonString(login)))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.id_token").exists());
+      .andExpect(cookie().exists(CookieService.OIDC_TOKEN_COOKIE_NAME));
   }
 }

--- a/src/test/java/org/sitmun/authentication/controller/AuthenticationControllerTest.java
+++ b/src/test/java/org/sitmun/authentication/controller/AuthenticationControllerTest.java
@@ -1,11 +1,14 @@
 package org.sitmun.authentication.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.sitmun.authentication.dto.AuthenticationResponse;
 import org.sitmun.authentication.dto.UserPasswordAuthenticationRequest;
 import org.sitmun.test.TestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +17,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -21,6 +25,7 @@ import org.springframework.test.web.servlet.MockMvc;
 class AuthenticationControllerTest {
 
   @Autowired private MockMvc mvc;
+  @Autowired private ObjectMapper objectMapper;
 
   @Test
   @DisplayName("POST: Admin user must login")
@@ -55,33 +60,28 @@ class AuthenticationControllerTest {
   @WithMockUser(
       username = "admin",
       roles = {"ADMIN"})
-  @DisplayName("POST /proxy: Authenticated user must get short-lived token cookie")
+  @DisplayName("POST /proxy: Authenticated user must get short-lived token in response")
   void proxyAuthenticationSuccess() throws Exception {
-    mvc.perform(post("/api/authenticate/proxy").secure(true))
+    MvcResult result = mvc.perform(post("/api/authenticate/proxy").secure(true))
         .andExpect(status().isOk())
-        .andExpect(cookie().exists(AuthenticationController.PROXY_TOKEN_COOKIE_NAME));
+        .andReturn();
+
+    String content = result.getResponse().getContentAsString();
+    AuthenticationResponse response = objectMapper.readValue(content, AuthenticationResponse.class);
+    assertThat(response.getProxyToken()).isNotNull().isNotEmpty();
   }
 
   @Test
   @WithMockUser(
       username = "admin",
       roles = {"ADMIN"})
-  @DisplayName("POST /proxy: Cookie must have secure flag when using HTTPS")
-  void proxyAuthenticationCookieSecure() throws Exception {
-    mvc.perform(post("/api/authenticate/proxy").secure(true))
+  @DisplayName("POST /proxy: Response must contain proxy_token field")
+  void proxyAuthenticationResponseContent() throws Exception {
+    MvcResult result = mvc.perform(post("/api/authenticate/proxy").secure(true))
         .andExpect(status().isOk())
-        .andExpect(cookie().path(AuthenticationController.PROXY_TOKEN_COOKIE_NAME, "/"))
-        .andExpect(cookie().secure(AuthenticationController.PROXY_TOKEN_COOKIE_NAME, true));
-  }
+        .andReturn();
 
-  @Test
-  @WithMockUser(
-      username = "admin",
-      roles = {"ADMIN"})
-  @DisplayName("POST /proxy: Cookie must not have secure flag when using HTTP")
-  void proxyAuthenticationCookieNotSecure() throws Exception {
-    mvc.perform(post("/api/authenticate/proxy").secure(false))
-        .andExpect(status().isOk())
-        .andExpect(cookie().secure(AuthenticationController.PROXY_TOKEN_COOKIE_NAME, false));
+    String content = result.getResponse().getContentAsString();
+    assertThat(content).containsIgnoringCase("proxyToken");
   }
 }

--- a/src/test/java/org/sitmun/authentication/controller/AuthenticationControllerTest.java
+++ b/src/test/java/org/sitmun/authentication/controller/AuthenticationControllerTest.java
@@ -1,12 +1,13 @@
 package org.sitmun.authentication.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.sitmun.authentication.dto.UserPasswordAuthenticationRequest;
+import org.sitmun.authentication.service.CookieService;
 import org.sitmun.test.TestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -33,7 +34,7 @@ class AuthenticationControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(TestUtils.asJsonString(login)))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.id_token").exists());
+        .andExpect(cookie().exists(CookieService.OIDC_TOKEN_COOKIE_NAME));
   }
 
   @Test

--- a/src/test/java/org/sitmun/authentication/controller/AuthenticationControllerTest.java
+++ b/src/test/java/org/sitmun/authentication/controller/AuthenticationControllerTest.java
@@ -7,12 +7,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.sitmun.authentication.dto.UserPasswordAuthenticationRequest;
-import org.sitmun.authentication.service.CookieService;
 import org.sitmun.test.TestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
@@ -34,7 +34,7 @@ class AuthenticationControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(TestUtils.asJsonString(login)))
         .andExpect(status().isOk())
-        .andExpect(cookie().exists(CookieService.OIDC_TOKEN_COOKIE_NAME));
+        .andExpect(cookie().exists(AuthenticationController.ACCESS_TOKEN_COOKIE_NAME));
   }
 
   @Test
@@ -49,5 +49,39 @@ class AuthenticationControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(TestUtils.asJsonString(login)))
         .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser(
+      username = "admin",
+      roles = {"ADMIN"})
+  @DisplayName("POST /proxy: Authenticated user must get short-lived token cookie")
+  void proxyAuthenticationSuccess() throws Exception {
+    mvc.perform(post("/api/authenticate/proxy").secure(true))
+        .andExpect(status().isOk())
+        .andExpect(cookie().exists(AuthenticationController.PROXY_TOKEN_COOKIE_NAME));
+  }
+
+  @Test
+  @WithMockUser(
+      username = "admin",
+      roles = {"ADMIN"})
+  @DisplayName("POST /proxy: Cookie must have secure flag when using HTTPS")
+  void proxyAuthenticationCookieSecure() throws Exception {
+    mvc.perform(post("/api/authenticate/proxy").secure(true))
+        .andExpect(status().isOk())
+        .andExpect(cookie().path(AuthenticationController.PROXY_TOKEN_COOKIE_NAME, "/"))
+        .andExpect(cookie().secure(AuthenticationController.PROXY_TOKEN_COOKIE_NAME, true));
+  }
+
+  @Test
+  @WithMockUser(
+      username = "admin",
+      roles = {"ADMIN"})
+  @DisplayName("POST /proxy: Cookie must not have secure flag when using HTTP")
+  void proxyAuthenticationCookieNotSecure() throws Exception {
+    mvc.perform(post("/api/authenticate/proxy").secure(false))
+        .andExpect(status().isOk())
+        .andExpect(cookie().secure(AuthenticationController.PROXY_TOKEN_COOKIE_NAME, false));
   }
 }

--- a/src/test/java/org/sitmun/authentication/controller/AuthenticationControllerTest.java
+++ b/src/test/java/org/sitmun/authentication/controller/AuthenticationControllerTest.java
@@ -75,13 +75,10 @@ class AuthenticationControllerTest {
   @WithMockUser(
       username = "admin",
       roles = {"ADMIN"})
-  @DisplayName("POST /proxy: Response must contain proxy_token field")
-  void proxyAuthenticationResponseContent() throws Exception {
-    MvcResult result = mvc.perform(post("/api/authenticate/proxy").secure(true))
+  @DisplayName("POST /logout: Authenticated user must logout successfully")
+  void logoutSuccess() throws Exception {
+    mvc.perform(post("/api/authenticate/logout").secure(true))
         .andExpect(status().isOk())
-        .andReturn();
-
-    String content = result.getResponse().getContentAsString();
-    assertThat(content).containsIgnoringCase("proxyToken");
+        .andExpect(cookie().maxAge(AuthenticationController.ACCESS_TOKEN_COOKIE_NAME, 0));
   }
 }

--- a/src/test/java/org/sitmun/authentication/handler/OidcAuthenticationSuccessHandlerTest.java
+++ b/src/test/java/org/sitmun/authentication/handler/OidcAuthenticationSuccessHandlerTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.sitmun.authentication.controller.AuthenticationController;
 import org.sitmun.authentication.service.CookieService;
 import org.sitmun.authentication.service.OidcRedirectService;
 import org.sitmun.domain.user.User;
@@ -51,7 +52,7 @@ class OidcAuthenticationSuccessHandlerTest {
   void setUp() {
     cookieService = new CookieService();
     ReflectionTestUtils.setField(cookieService, "tokenCookieHttpOnly", false);
-    ReflectionTestUtils.setField(cookieService, "accessTokenMaxAge", 3600);
+    ReflectionTestUtils.setField(cookieService, "tokenValidityInMillis", 36000000);
     ReflectionTestUtils.setField(cookieService, "sameSiteCookie", "Strict");
     handler =
         new OidcAuthenticationSuccessHandler(
@@ -60,6 +61,7 @@ class OidcAuthenticationSuccessHandlerTest {
             userDetailsService,
             jsonWebTokenService,
             cookieService);
+    ReflectionTestUtils.setField(handler, "validity", 3600);
   }
 
   private static OAuth2AuthenticationToken oauth2TokenWithOidcUser(
@@ -96,7 +98,7 @@ class OidcAuthenticationSuccessHandlerTest {
     assertThat(response.getRedirectedUrl()).isEqualTo(REDIRECT_URL);
     Cookie[] cookies = response.getCookies();
     assertThat(cookies).isNotNull().hasSize(1);
-    assertThat(cookies[0].getName()).isEqualTo(CookieService.OIDC_TOKEN_COOKIE_NAME);
+    assertThat(cookies[0].getName()).isEqualTo(AuthenticationController.ACCESS_TOKEN_COOKIE_NAME);
     assertThat(cookies[0].getValue()).isEqualTo(JWT_TOKEN);
     assertThat(cookies[0].isHttpOnly()).isFalse();
     assertThat(cookies[0].getPath()).isEqualTo("/");

--- a/src/test/java/org/sitmun/authentication/handler/OidcAuthenticationSuccessHandlerTest.java
+++ b/src/test/java/org/sitmun/authentication/handler/OidcAuthenticationSuccessHandlerTest.java
@@ -55,7 +55,11 @@ class OidcAuthenticationSuccessHandlerTest {
     ReflectionTestUtils.setField(cookieService, "sameSiteCookie", "Strict");
     handler =
         new OidcAuthenticationSuccessHandler(
-            userRepository, redirectService, userDetailsService, jsonWebTokenService, cookieService);
+            userRepository,
+            redirectService,
+            userDetailsService,
+            jsonWebTokenService,
+            cookieService);
   }
 
   private static OAuth2AuthenticationToken oauth2TokenWithOidcUser(
@@ -92,8 +96,7 @@ class OidcAuthenticationSuccessHandlerTest {
     assertThat(response.getRedirectedUrl()).isEqualTo(REDIRECT_URL);
     Cookie[] cookies = response.getCookies();
     assertThat(cookies).isNotNull().hasSize(1);
-    assertThat(cookies[0].getName())
-        .isEqualTo(CookieService.OIDC_TOKEN_COOKIE_NAME);
+    assertThat(cookies[0].getName()).isEqualTo(CookieService.OIDC_TOKEN_COOKIE_NAME);
     assertThat(cookies[0].getValue()).isEqualTo(JWT_TOKEN);
     assertThat(cookies[0].isHttpOnly()).isFalse();
     assertThat(cookies[0].getPath()).isEqualTo("/");

--- a/src/test/java/org/sitmun/authentication/handler/OidcAuthenticationSuccessHandlerTest.java
+++ b/src/test/java/org/sitmun/authentication/handler/OidcAuthenticationSuccessHandlerTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.sitmun.authentication.service.CookieService;
 import org.sitmun.authentication.service.OidcRedirectService;
 import org.sitmun.domain.user.User;
 import org.sitmun.domain.user.UserRepository;
@@ -42,14 +43,19 @@ class OidcAuthenticationSuccessHandlerTest {
 
   @Mock private JsonWebTokenService jsonWebTokenService;
 
+  private CookieService cookieService;
+
   private OidcAuthenticationSuccessHandler handler;
 
   @BeforeEach
   void setUp() {
+    cookieService = new CookieService();
+    ReflectionTestUtils.setField(cookieService, "tokenCookieHttpOnly", false);
+    ReflectionTestUtils.setField(cookieService, "accessTokenMaxAge", 3600);
+    ReflectionTestUtils.setField(cookieService, "sameSiteCookie", "Strict");
     handler =
         new OidcAuthenticationSuccessHandler(
-            userRepository, redirectService, userDetailsService, jsonWebTokenService);
-    ReflectionTestUtils.setField(handler, "oidcCookieHttpOnly", false);
+            userRepository, redirectService, userDetailsService, jsonWebTokenService, cookieService);
   }
 
   private static OAuth2AuthenticationToken oauth2TokenWithOidcUser(
@@ -87,7 +93,7 @@ class OidcAuthenticationSuccessHandlerTest {
     Cookie[] cookies = response.getCookies();
     assertThat(cookies).isNotNull().hasSize(1);
     assertThat(cookies[0].getName())
-        .isEqualTo(OidcAuthenticationSuccessHandler.OIDC_TOKEN_COOKIE_NAME);
+        .isEqualTo(CookieService.OIDC_TOKEN_COOKIE_NAME);
     assertThat(cookies[0].getValue()).isEqualTo(JWT_TOKEN);
     assertThat(cookies[0].isHttpOnly()).isFalse();
     assertThat(cookies[0].getPath()).isEqualTo("/");
@@ -161,7 +167,7 @@ class OidcAuthenticationSuccessHandlerTest {
   @Test
   @DisplayName("cookie httpOnly flag respects config")
   void cookieHttpOnlyFlag_respectsConfig() throws Exception {
-    ReflectionTestUtils.setField(handler, "oidcCookieHttpOnly", true);
+    ReflectionTestUtils.setField(cookieService, "tokenCookieHttpOnly", true);
     MockHttpServletRequest request = new MockHttpServletRequest();
     MockHttpServletResponse response = new MockHttpServletResponse();
     when(redirectService.selectRedirectUrl(request)).thenReturn(REDIRECT_URL);

--- a/src/test/java/org/sitmun/authentication/oidc/OidcLoginUnitTest.java
+++ b/src/test/java/org/sitmun/authentication/oidc/OidcLoginUnitTest.java
@@ -16,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.sitmun.authentication.handler.OidcAuthenticationSuccessHandler;
+import org.sitmun.authentication.service.CookieService;
 import org.sitmun.authentication.service.OidcRedirectService;
 import org.sitmun.domain.user.User;
 import org.sitmun.domain.user.UserRepository;
@@ -41,6 +42,8 @@ class OidcLoginUnitTest {
   @Mock private JsonWebTokenService jsonWebTokenService;
 
   @InjectMocks private OidcAuthenticationSuccessHandler successHandler;
+
+  @InjectMocks private CookieService cookieService;
 
   @Test
   @DisplayName("Cookie is set on successful OIDC authentication")
@@ -75,13 +78,13 @@ class OidcLoginUnitTest {
     when(redirectService.selectRedirectUrl(any())).thenReturn("/success");
 
     final Field field =
-        OidcAuthenticationSuccessHandler.class.getDeclaredField("oidcCookieHttpOnly");
+        CookieService.class.getDeclaredField("tokenCookieHttpOnly");
     field.setAccessible(true);
-    field.set(successHandler, Boolean.TRUE);
+    field.set(cookieService, Boolean.TRUE);
 
     successHandler.onAuthenticationSuccess(request, response, auth);
     Arrays.stream(response.getCookies())
-        .filter(cookie -> "oidc_token".equals(cookie.getName()))
+        .filter(cookie -> "jwt_token".equals(cookie.getName()))
         .findFirst()
         .ifPresent(
             cookie -> {

--- a/src/test/java/org/sitmun/authentication/oidc/OidcLoginUnitTest.java
+++ b/src/test/java/org/sitmun/authentication/oidc/OidcLoginUnitTest.java
@@ -77,8 +77,7 @@ class OidcLoginUnitTest {
         new OAuth2AuthenticationToken(oidcUser, java.util.List.of(), "mock");
     when(redirectService.selectRedirectUrl(any())).thenReturn("/success");
 
-    final Field field =
-        CookieService.class.getDeclaredField("tokenCookieHttpOnly");
+    final Field field = CookieService.class.getDeclaredField("tokenCookieHttpOnly");
     field.setAccessible(true);
     field.set(cookieService, Boolean.TRUE);
 

--- a/src/test/java/org/sitmun/authentication/oidc/OidcLoginUnitTest.java
+++ b/src/test/java/org/sitmun/authentication/oidc/OidcLoginUnitTest.java
@@ -83,7 +83,7 @@ class OidcLoginUnitTest {
 
     successHandler.onAuthenticationSuccess(request, response, auth);
     Arrays.stream(response.getCookies())
-        .filter(cookie -> "jwt_token".equals(cookie.getName()))
+        .filter(cookie -> "access_token".equals(cookie.getName()))
         .findFirst()
         .ifPresent(
             cookie -> {

--- a/src/test/java/org/sitmun/domain/database/DatabaseConnectionRepositoryIntegrationTest.java
+++ b/src/test/java/org/sitmun/domain/database/DatabaseConnectionRepositoryIntegrationTest.java
@@ -10,8 +10,6 @@ import net.minidev.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.*;
-import org.sitmun.authentication.dto.AuthenticationResponse;
-import org.sitmun.authentication.dto.UserPasswordAuthenticationRequest;
 import org.sitmun.test.ClientHttpLoggerRequestInterceptor;
 import org.sitmun.test.TestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -80,7 +78,10 @@ class DatabaseConnectionRepositoryIntegrationTest {
   @DisplayName("GET: List DatabaseConnection")
   void requestConnections() {
     HttpHeaders headers = new HttpHeaders();
-    headers.set(HttpHeaders.AUTHORIZATION, TestUtils.requestAuthorization(restTemplate, port));
+    headers.add(
+        HttpHeaders.COOKIE,
+        "access_token="
+            + TestUtils.requestAuthorization(restTemplate, port)); // Use token in cookies
     HttpEntity<Void> entity = new HttpEntity<>(headers);
 
     ResponseEntity<String> response =
@@ -164,19 +165,15 @@ class DatabaseConnectionRepositoryIntegrationTest {
   }
 
   private String getAuthorization() {
-    UserPasswordAuthenticationRequest login = new UserPasswordAuthenticationRequest();
-    login.setUsername("admin");
-    login.setPassword("admin");
-    ResponseEntity<AuthenticationResponse> loginResponse =
-        restTemplate.postForEntity(
-            "http://localhost:{port}/api/authenticate", login, AuthenticationResponse.class, port);
-    assertThat(loginResponse.getBody()).isNotNull();
-    return loginResponse.getBody().getIdToken();
+    return TestUtils.requestAuthorization(restTemplate, port);
   }
 
   private JSONObject getConnection(int id) throws JSONException {
     HttpHeaders headers = new HttpHeaders();
-    headers.set(HttpHeaders.AUTHORIZATION, TestUtils.requestAuthorization(restTemplate, port));
+    headers.add(
+        HttpHeaders.COOKIE,
+        "access_token="
+            + TestUtils.requestAuthorization(restTemplate, port)); // Use token in cookies
     HttpEntity<Void> entity = new HttpEntity<>(headers);
 
     String uri = "http://localhost:" + port + "/api/connections/" + id;
@@ -189,7 +186,10 @@ class DatabaseConnectionRepositoryIntegrationTest {
 
   private JSONObject getConnectionCartographies(int id) throws JSONException {
     HttpHeaders headers = new HttpHeaders();
-    headers.set(HttpHeaders.AUTHORIZATION, TestUtils.requestAuthorization(restTemplate, port));
+    headers.add(
+        HttpHeaders.COOKIE,
+        "access_token="
+            + TestUtils.requestAuthorization(restTemplate, port)); // Use token in cookies
     HttpEntity<Void> entity = new HttpEntity<>(headers);
 
     String uri = "http://localhost:" + port + "/api/connections/" + id + "/cartographies";
@@ -202,7 +202,7 @@ class DatabaseConnectionRepositoryIntegrationTest {
 
   private boolean hasCartographiesSpatialSelectionConnection(int id, String auth) {
     HttpHeaders headers = new HttpHeaders();
-    headers.setBearerAuth(auth);
+    headers.add(HttpHeaders.COOKIE, "access_token=" + auth);
     try {
       restTemplate.exchange(
           "http://localhost:" + port + "/api/cartographies/" + id + "/spatialSelectionConnection",
@@ -220,7 +220,7 @@ class DatabaseConnectionRepositoryIntegrationTest {
 
   private void deleteCartographiesSpatialSelectionConnection(int id, String auth) {
     HttpHeaders headers = new HttpHeaders();
-    headers.setBearerAuth(auth);
+    headers.add(HttpHeaders.COOKIE, "access_token=" + auth);
     restTemplate.exchange(
         "http://localhost:" + port + "/api/cartographies/" + id + "/spatialSelectionConnection",
         HttpMethod.DELETE,
@@ -232,7 +232,7 @@ class DatabaseConnectionRepositoryIntegrationTest {
       int id, List<String> newValue, String auth) {
     HttpHeaders headers = new HttpHeaders();
     headers.setContentType(MediaType.parseMediaType("text/uri-list"));
-    headers.setBearerAuth(auth);
+    headers.add(HttpHeaders.COOKIE, "access_token=" + auth);
     restTemplate.exchange(
         "http://localhost:" + port + "/api/cartographies/" + id + "/spatialSelectionConnection",
         HttpMethod.PUT,
@@ -243,7 +243,7 @@ class DatabaseConnectionRepositoryIntegrationTest {
   private void updateConnectionCartograhies(int id, List<String> newValue, String auth) {
     HttpHeaders headers = new HttpHeaders();
     headers.setContentType(MediaType.parseMediaType("text/uri-list"));
-    headers.setBearerAuth(auth);
+    headers.add(HttpHeaders.COOKIE, "access_token=" + auth);
     restTemplate.exchange(
         "http://localhost:" + port + "/api/connections/" + id + "/cartographies",
         HttpMethod.PUT,
@@ -254,7 +254,7 @@ class DatabaseConnectionRepositoryIntegrationTest {
   private void updateConnection(int id, JSONObject newValue, String auth) {
     HttpHeaders headers = new HttpHeaders();
     headers.setContentType(MediaType.APPLICATION_JSON);
-    headers.setBearerAuth(auth);
+    headers.add(HttpHeaders.COOKIE, "access_token=" + auth);
     restTemplate.exchange(
         "http://localhost:" + port + "/api/connections/" + id,
         HttpMethod.PUT,

--- a/src/test/java/org/sitmun/domain/role/RoleRepositoryIntegrationTest.java
+++ b/src/test/java/org/sitmun/domain/role/RoleRepositoryIntegrationTest.java
@@ -60,7 +60,8 @@ class RoleRepositoryIntegrationTest {
   @Test
   void requestRoles() {
     HttpHeaders headers = new HttpHeaders();
-    headers.set(HttpHeaders.AUTHORIZATION, TestUtils.requestAuthorization(restTemplate, port));
+    String accessToken = TestUtils.requestAuthorization(restTemplate, port);
+    headers.set(HttpHeaders.COOKIE, "access_token=" + accessToken);
     HttpEntity<Void> entity = new HttpEntity<>(headers);
 
     ResponseEntity<String> response =

--- a/src/test/java/org/sitmun/domain/territory/TerritoryRepositoryIntegrationTest.java
+++ b/src/test/java/org/sitmun/domain/territory/TerritoryRepositoryIntegrationTest.java
@@ -43,7 +43,10 @@ class TerritoryRepositoryIntegrationTest {
   @Test
   void requestMembers() {
     HttpHeaders headers = new HttpHeaders();
-    headers.set(HttpHeaders.AUTHORIZATION, TestUtils.requestAuthorization(restTemplate, port));
+    headers.add(
+        HttpHeaders.COOKIE,
+        "access_token="
+            + TestUtils.requestAuthorization(restTemplate, port)); // Use token in cookies
     HttpEntity<Void> entity = new HttpEntity<>(headers);
 
     ResponseEntity<String> response =
@@ -61,7 +64,8 @@ class TerritoryRepositoryIntegrationTest {
   @Test
   void requestMemberOf() {
     HttpHeaders headers = new HttpHeaders();
-    headers.set(HttpHeaders.AUTHORIZATION, TestUtils.requestAuthorization(restTemplate, port));
+    headers.add(
+        HttpHeaders.COOKIE, "access_token=" + TestUtils.requestAuthorization(restTemplate, port));
     HttpEntity<Void> entity = new HttpEntity<>(headers);
 
     ResponseEntity<String> response =

--- a/src/test/java/org/sitmun/domain/territory/type/TerritoryGroupTypeRepositoryIntegrationTest.java
+++ b/src/test/java/org/sitmun/domain/territory/type/TerritoryGroupTypeRepositoryIntegrationTest.java
@@ -65,7 +65,7 @@ class TerritoryGroupTypeRepositoryIntegrationTest {
   @Test
   void requestRoles() {
     HttpHeaders headers = new HttpHeaders();
-    headers.set(HttpHeaders.AUTHORIZATION, TestUtils.requestAuthorization(restTemplate, port));
+    headers.set(HttpHeaders.COOKIE, "access_token=" + TestUtils.requestAuthorization(restTemplate, port));
     HttpEntity<Void> entity = new HttpEntity<>(headers);
 
     ResponseEntity<String> response =

--- a/src/test/java/org/sitmun/domain/user/UserControllerTest.java
+++ b/src/test/java/org/sitmun/domain/user/UserControllerTest.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.Optional;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -19,7 +20,6 @@ import org.sitmun.test.URIConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -35,6 +35,7 @@ class UserControllerTest {
   private static final String USER_LASTNAME = "Admin";
   private static final Boolean USER_BLOCKED = false;
   private static final Boolean USER_ADMINISTRATOR = false;
+  public static final String ACCESS_TOKEN = "access_token";
   @Autowired JsonWebTokenService tokenProvider;
   @Autowired private MockMvc mvc;
   @Autowired private UserRepository userRepository;
@@ -74,7 +75,7 @@ class UserControllerTest {
   @DisplayName("GET: Read user account with valid token")
   void readAccount() throws Exception {
     mvc.perform(
-            get(URIConstants.ACCOUNT_URI).header(HttpHeaders.AUTHORIZATION, "Bearer " + validToken))
+            get(URIConstants.ACCOUNT_URI).cookie(new Cookie(ACCESS_TOKEN, validToken)))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.firstName", equalTo(USER_FIRSTNAME)))
@@ -91,8 +92,7 @@ class UserControllerTest {
   @DisplayName("GET: Read user account with expired token should fail")
   void readAccountWithExpiredToken() throws Exception {
     mvc.perform(
-            get(URIConstants.ACCOUNT_URI)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + expiredToken))
+            get(URIConstants.ACCOUNT_URI).cookie(new Cookie(ACCESS_TOKEN, expiredToken)))
         .andExpect(status().isUnauthorized());
   }
 
@@ -109,13 +109,13 @@ class UserControllerTest {
 
     mvc.perform(
             post(URIConstants.ACCOUNT_URI)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + validToken)
+                .cookie(new Cookie(ACCESS_TOKEN, validToken))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(content))
         .andExpect(status().isOk());
 
     mvc.perform(
-            get(URIConstants.ACCOUNT_URI).header(HttpHeaders.AUTHORIZATION, "Bearer " + validToken))
+            get(URIConstants.ACCOUNT_URI).cookie(new Cookie(ACCESS_TOKEN, validToken)))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.firstName", equalTo("NameChanged")))
@@ -144,7 +144,7 @@ class UserControllerTest {
 
     mvc.perform(
             post(URIConstants.ACCOUNT_URI)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + validToken)
+                .cookie(new Cookie(ACCESS_TOKEN, validToken))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(content))
         .andExpect(status().isOk())

--- a/src/test/java/org/sitmun/domain/user/UserResourceIntegrationTest.java
+++ b/src/test/java/org/sitmun/domain/user/UserResourceIntegrationTest.java
@@ -69,7 +69,7 @@ class UserResourceIntegrationTest {
   @DisplayName("POST: Create new user and delete")
   void createNewUserAndDelete() {
     HttpHeaders headers = new HttpHeaders();
-    headers.set(HttpHeaders.AUTHORIZATION, TestUtils.requestAuthorization(restTemplate, port));
+    headers.set(HttpHeaders.COOKIE, "access_token=" + TestUtils.requestAuthorization(restTemplate, port));
 
     User newUser = organizacionAdmin.toBuilder().id(null).username(NEW_USER_USERNAME).build();
     HttpEntity<User> entity = new HttpEntity<>(newUser, headers);
@@ -112,7 +112,7 @@ class UserResourceIntegrationTest {
   @DisplayName("GET: Get all users")
   void getAllUsers() {
     HttpHeaders headers = new HttpHeaders();
-    headers.set(HttpHeaders.AUTHORIZATION, TestUtils.requestAuthorization(restTemplate, port));
+    headers.set(HttpHeaders.COOKIE, "access_token=" + TestUtils.requestAuthorization(restTemplate, port));
 
     ResponseEntity<CollectionModel<User>> response =
         restTemplate.exchange(

--- a/src/test/java/org/sitmun/test/TestUtils.java
+++ b/src/test/java/org/sitmun/test/TestUtils.java
@@ -6,6 +6,7 @@ import java.net.URI;
 import org.assertj.core.api.Assertions;
 import org.sitmun.authentication.dto.AuthenticationResponse;
 import org.sitmun.authentication.dto.UserPasswordAuthenticationRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
@@ -35,8 +36,14 @@ public class TestUtils {
     ResponseEntity<AuthenticationResponse> loginResponse =
         restTemplate.postForEntity(
             "http://localhost:{port}/api/authenticate", login, AuthenticationResponse.class, port);
-    Assertions.assertThat(loginResponse.getBody()).isNotNull();
-    return "Bearer " + loginResponse.getBody().getIdToken();
+    Assertions.assertThat(loginResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    String accessTokenCookie = loginResponse.getHeaders().getFirst("Set-Cookie");
+    if (accessTokenCookie != null && accessTokenCookie.contains("access_token=")) {
+      return accessTokenCookie.split(";")[0].split("=")[1];
+    }
+
+    return null;
   }
 
   public static Integer extractId(String url) {

--- a/src/test/resources/application-oidc.yml
+++ b/src/test/resources/application-oidc.yml
@@ -1,10 +1,12 @@
 sitmun:
   authentication:
+    http-only-cookie: false
+    access-token-max-age: 3600
+    same-site-cookie: Strict
     oidc:
       frontend-redirect-url-admin: "http://localhost:4200/#/callback"
       frontend-redirect-url-viewer: "http://localhost:4201/callback"
       frontend-redirect-url: "http://localhost:4200/default"
-      http-only-cookie: false
       providers:
         mock:
           provider-name: "mock"


### PR DESCRIPTION
- Switch to cookie-based tokens
- Separate tokens for backend core and proxy middleware.
- Proxy token is sent in JSON response and short-lived
- Token validity periods are customizable in application.yml/env vars
- access_token unifies previously separated OIDC and regular login tokens
- Updated documentation and tests